### PR TITLE
Don't try to get window.top.location.href

### DIFF
--- a/utils/networking.js
+++ b/utils/networking.js
@@ -14,7 +14,7 @@ const DB_ENDPOINT = 'https://api.zesty.market/api';
 
 const fetchCampaignAd = async (adUnitId, format = 'tall', style = 'standard') => {
   try {
-    const url = encodeURI(window.top.location.href).replace(/\/$/, ''); // If URL ends with a slash, remove it
+    const url = encodeURI(window.location.href).replace(/\/$/, ''); // If URL ends with a slash, remove it
     const res = await axios.get(`${DB_ENDPOINT}/ad?ad_unit_id=${adUnitId}&url=${url}`);
     if (res.data)
       return res.data;


### PR DESCRIPTION
Some iframe embedding restrictions will cause window.top.location.href to no longer be accessible, preventing campaign requests from reaching the ad server. Given that this is being handled elsewhere now, it can be switched back to just window.location.href.