### PR TITLE
Temporarily disable Github actions on PR

### DIFF
--- a/.github/workflows/check-deploy.yml
+++ b/.github/workflows/check-deploy.yml
@@ -1,7 +1,6 @@
 name: check-deploy
 
 on:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
We should technically separate the deploy and build scripts.