### PR TITLE
Fix some API issues in the WLE SDK

### DIFF
--- a/wonderland/package.json
+++ b/wonderland/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zestymarket/wonderland-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Wonderland Engine SDK for Zesty Banner integration.",
   "main": "dist/zesty-wonderland-sdk.js",
   "exports": {
@@ -16,14 +16,12 @@
   "wonderlandengine": {},
   "author": "",
   "license": "MIT",
-  "peerDependencies": {
-    "@wonderlandengine/api": "^1.0.0 || ^1.0.0-rc.5",
-    "@wonderlandengine/components": "^1.0.0 || ^1.0.0-rc.6"
+  "dependencies": {
+    "@wonderlandengine/api": "^1.0.0",
+    "@wonderlandengine/components": "^1.0.0",
+    "gl-matrix": "^3.4.3"
   },
   "devDependencies": {
     "esbuild": "^0.17.18"
-  },
-  "dependencies": {
-    "gl-matrix": "^3.4.3"
   }
 }

--- a/wonderland/src/index.js
+++ b/wonderland/src/index.js
@@ -7,6 +7,7 @@ import { version } from '../package.json';
 import {
   Component,
   Collider,
+  MeshAttribute,
   MeshComponent,
   CollisionComponent,
   Property
@@ -127,7 +128,7 @@ export class ZestyBanner extends Component {
   }
 
   startLoading() {
-    const camera = WL.scene.activeViews[0];
+    const camera = this.engine.scene.activeViews[0];
     const worldTransform = camera.object.getTransformWorld([]);
     const worldMatrix = mat4.fromQuat2([], worldTransform);
     const { bbMin, bbMax } = this.calculateBoundingBox();
@@ -210,7 +211,7 @@ export class ZestyBanner extends Component {
           }
         } else {
           throw Error(
-            "'zesty-banner' unable to apply banner texture: unsupported pipeline " + pipeline
+            "'zesty-banner' unable to apply banner texture: unsupported pipeline"
           );
         }
         this.mesh.material = m;
@@ -220,7 +221,7 @@ export class ZestyBanner extends Component {
         this.mesh.material.alphaMaskTexture = banner.texture;
       }
       if (this.beacon && !sdkLoaded) {
-        this.dynamicNetworking ?
+        this.dynamicNetworking && this.zestyNetworking?.sendOnLoadMetric ?
           this.zestyNetworking.sendOnLoadMetric(this.adUnit, this.banner.campaignId) :
           sendOnLoadMetric(this.adUnit, this.banner.campaignId);
         sdkLoaded = true;
@@ -243,14 +244,14 @@ export class ZestyBanner extends Component {
   executeClick() {
     openURL(this.banner.url);
     if (this.beacon) {
-      this.dynamicNetworking ?
+      this.dynamicNetworking && this.zestyNetworking?.sendOnClickMetric ?
         this.zestyNetworking.sendOnClickMetric(this.adUnit, this.banner.campaignId) :
         sendOnClickMetric(this.adUnit, this.banner.campaignId);
     }
   }
 
   async loadBanner(adUnit, format, style) {
-    const activeCampaign = this.dynamicNetworking ?
+    const activeCampaign = this.dynamicNetworking && this.zestyNetworking?.fetchCampaignAd ?
       await this.zestyNetworking.fetchCampaignAd(adUnit, format, style) :
       await fetchCampaignAd(adUnit, format, style);
 
@@ -284,7 +285,7 @@ export class ZestyBanner extends Component {
    * @returns {{bbMin: number[], bbMax: number[]}}
    */
   calculateBoundingBox() {
-    const vertices = this.mesh.mesh.attribute(WL.MeshAttribute.Position);
+    const vertices = this.mesh.mesh.attribute(MeshAttribute.Position);
     const worldPosition = this.object.getPositionWorld([]);
     const scale = this.object.getScalingLocal([]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,6 +1329,11 @@
   resolved "https://registry.yarnpkg.com/@types/draco3d/-/draco3d-1.4.10.tgz#63ec0ba78b30bd58203ec031f4e4f0198c596dca"
   integrity sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==
 
+"@types/earcut@^2.1.1":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/earcut/-/earcut-2.1.4.tgz#5811d7d333048f5a7573b22ddc84923e69596da6"
+  integrity sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
@@ -1494,6 +1499,11 @@
   resolved "https://registry.yarnpkg.com/@types/webxr/-/webxr-0.5.18.tgz#1f84f09f52a8045969ed064525e94197f6642cd9"
   integrity sha512-EM8P5wtYMPUlFbDgKfNoPc5PyhgZvwXz0Wf9gYBfJOpTI8AtPzoLJlvw/D9TmIW/LPLTmwMxWI0axBs3hjLSLg==
 
+"@types/webxr@^0.5.0":
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/@types/webxr/-/webxr-0.5.19.tgz#463a27bc06ff1c0a0c997e86b48bf24c5f50a4af"
+  integrity sha512-4hxA+NwohSgImdTSlPXEqDqqFktNgmTXQ05ff1uWam05tNGroCMp4G+4XVl6qWm1p7GQ/9oD41kAYsSssF6Mzw==
+
 "@types/ws@^8.5.5":
   version "8.5.10"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.10.tgz#4acfb517970853fa6574a3a6886791d04a396787"
@@ -1643,6 +1653,25 @@
   version "1.7.0"
   resolved "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz"
   integrity sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
+
+"@wonderlandengine/api@^1.0.0":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@wonderlandengine/api/-/api-1.2.2.tgz#229beb9c4988fdee3975cbc7776ffc1f5552b505"
+  integrity sha512-2Rou/kvNk0451D8B5MpZbzpi9ywtUyVthMM158BhtSzYVqWDRH3ZQDhsywTWhm4OWWw3pYEy7PJHAIlPcG9vUA==
+  dependencies:
+    "@types/webxr" "^0.5.0"
+    wasm-feature-detect "^1.3.0"
+
+"@wonderlandengine/components@^1.0.0":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@wonderlandengine/components/-/components-1.1.5.tgz#df592c29aeebcec9a5031ac929c2d48c0e4c9949"
+  integrity sha512-xWCnahro4I+ogSbblOs8b3CkOFW60RAbUWv3NsYrEU4zxKHVbj2ziLA18S+6HM9WpHUgaXP60vZhq7V7soxYcA==
+  dependencies:
+    "@types/earcut" "^2.1.1"
+    "@types/webxr" "^0.5.0"
+    earcut "^2.2.4"
+    gl-matrix "^3.3.0"
+    howler "^2.2.1"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -2357,6 +2386,11 @@ draco3d@^1.4.1:
   resolved "https://registry.yarnpkg.com/draco3d/-/draco3d-1.5.7.tgz#94f9bce293eb8920c159dc91a4ce9124a9e899e0"
   integrity sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==
 
+earcut@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.4.tgz#6d02fd4d68160c114825d06890a92ecaae60343a"
+  integrity sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
@@ -3045,7 +3079,7 @@ get-symbol-description@^1.0.2:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
 
-gl-matrix@^3.4.3:
+gl-matrix@^3.3.0, gl-matrix@^3.4.3:
   version "3.4.3"
   resolved "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz"
   integrity sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==
@@ -3175,6 +3209,11 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+howler@^2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/howler/-/howler-2.2.4.tgz#bd3df4a4f68a0118a51e4bd84a2bfc2e93e6e5a1"
+  integrity sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -5018,6 +5057,11 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+wasm-feature-detect@^1.3.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/wasm-feature-detect/-/wasm-feature-detect-1.6.2.tgz#d6229cae95311d82cc6c0c3b6934173c222ccbed"
+  integrity sha512-4dnaZ+Fq/q+BbMlTIfaNS851i+0zmHzui++NUZdskESRu3xwB6g6x2FnGvBdWtpijqO5yuj1l+EUTJGc4S4DKg==
 
 watchpack@^2.4.1:
   version "2.4.1"


### PR DESCRIPTION
There were still a couple uses of the global `WL`, which has actually already been deprecated. Additionally, we weren't handling the case of if dynamicNetworking was enabled but the script failed to load. This adds proper checks for that, along with promoting the Wonderland peer deps to full deps.