### PR TITLE
Bump beacon version

### DIFF
--- a/utils/package.json
+++ b/utils/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.27.2",
-    "sig-beacon": "^0.0.4",
+    "sig-beacon": "^0.0.5",
     "three": "^0.166.1",
     "uuid": "^8.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4653,10 +4653,10 @@ side-channel@^1.0.6:
     get-intrinsic "^1.2.4"
     object-inspect "^1.13.1"
 
-sig-beacon@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/sig-beacon/-/sig-beacon-0.0.4.tgz#d3d7d1f8c96ca775fe3fc04f0afc87609082dc96"
-  integrity sha512-PRODDIqOwi6zfKqtdLOBFs3sWCjYDrKWOTJ2jo0+FCstAFtm7KAJyTmidkOqrP3zablwLZsl4ukU2yB1SblrIg==
+sig-beacon@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/sig-beacon/-/sig-beacon-0.0.5.tgz#e4b5d8e266245bf49d3b1f52789edecf82915ae8"
+  integrity sha512-2g57+yCoopwWFGB1cIOH7ZdqnRuVmDqR5Pa8kYyq94kBjzNqoZC0InFyxmHGs/WyNTDdrCYUGEbwyC012hulrQ==
 
 signal-exit@^3.0.3:
   version "3.0.7"


### PR DESCRIPTION
Old version had a copy paste error when checking for relay URL, this version fixes that