### PR TITLE
Bump three.js package.json version

### DIFF
--- a/threejs/package.json
+++ b/threejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zestymarket/threejs-sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "This is the three.js SDK for Zesty Banner integration.",
   "main": "dist/zesty-threejs-sdk.js",
   "scripts": {


### PR DESCRIPTION
This includes the relay functionality, which was accidentally excluded from the previous version bump