### PR TITLE
Update URL to point at prod relay

### DIFF
--- a/utils/networking.js
+++ b/utils/networking.js
@@ -25,7 +25,7 @@ let divCount = 0;
 
 // Instantiate the beacon prototype as an import side-effect for now
 // just so we don't need to modify all the other SDKs
-const beacon = new Beacon('https://relay-dev.zesty.xyz');
+const beacon = new Beacon('https://relay.zesty.xyz');
 beacon.signal();
 
 const initPrebid = (adUnitId, format) => {

--- a/utils/package.json
+++ b/utils/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.27.2",
-    "sig-beacon": "^0.0.8",
+    "sig-beacon": "^0.0.9",
     "three": "^0.166.1",
     "uuid": "^8.3.2"
   },

--- a/utils/package.json
+++ b/utils/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.27.2",
-    "sig-beacon": "^0.0.6",
+    "sig-beacon": "^0.0.8",
     "three": "^0.166.1",
     "uuid": "^8.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4653,10 +4653,10 @@ side-channel@^1.0.6:
     get-intrinsic "^1.2.4"
     object-inspect "^1.13.1"
 
-sig-beacon@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/sig-beacon/-/sig-beacon-0.0.8.tgz#aac646e249a87e069c700489c15d1a8ea48f054f"
-  integrity sha512-qplHVzhyEVCpCBTeeQO56Mihjx9qBWiNzESo7a6ttcjARxLFwlEtjlerOB7qdMOQEVHU/kRDfIe8BFKmakVApA==
+sig-beacon@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/sig-beacon/-/sig-beacon-0.0.9.tgz#58ad3eb3fdf04a276985f0b78906054599e7b6ee"
+  integrity sha512-+rDaRwahYBgnuMiqbk/oBDPwbN2T2spBSTgtQCliq1+wu0+5qOk+6LgjKcWI+NtJ8/r6czJLoOUG/aFLp70vCA==
 
 signal-exit@^3.0.3:
   version "3.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4653,10 +4653,10 @@ side-channel@^1.0.6:
     get-intrinsic "^1.2.4"
     object-inspect "^1.13.1"
 
-sig-beacon@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/sig-beacon/-/sig-beacon-0.0.6.tgz#10ebd449b02a2238979f1f76776b62edc5ac9a87"
-  integrity sha512-PNijbCZXtBiHo6sU0EIHBu6uvbicnucS9O3XLrEJEGd1FUp1POAQ0z53iEXbGShErBhdkKHXKjHJ6toFpBvMYw==
+sig-beacon@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/sig-beacon/-/sig-beacon-0.0.8.tgz#aac646e249a87e069c700489c15d1a8ea48f054f"
+  integrity sha512-qplHVzhyEVCpCBTeeQO56Mihjx9qBWiNzESo7a6ttcjARxLFwlEtjlerOB7qdMOQEVHU/kRDfIe8BFKmakVApA==
 
 signal-exit@^3.0.3:
   version "3.0.7"


### PR DESCRIPTION
Updates networking.js to point at the prod version of the relay. Opening as draft for now because I discovered that the automatic canvas screenshotting doesn't work as expected with WebGL-context canvases (the image it grabs with `.toDataURL()` is empty due to how WebGL rendering works) and I still need to find a good workaround for it. Once that's figured out everything else should be in place to bump the beacon version and make the switch.