### PR TITLE
Lower refresh interval to 5 seconds

### DIFF
--- a/utils/networking.js
+++ b/utils/networking.js
@@ -12,7 +12,7 @@ const DB_ENDPOINT = 'https://api.zesty.market/api';
 // const STAGING_DB_ENDPOINT = 'https://api-staging.zesty.market/api';
 
 // Prebid variables
-const AD_REFRESH_INTERVAL = 10000;
+const AD_REFRESH_INTERVAL = 5000;
 let prebidInit = false;
 let interval = null;
 const retryCount = 5;


### PR DESCRIPTION
This is probably towards the lower end of how often we can refresh before hitting a rate limit from aditude, but I can't seem to access their docs to confirm that right now.