### PR TITLE
Bump beacon ver to include new image checks

### DIFF
--- a/utils/package.json
+++ b/utils/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.27.2",
-    "sig-beacon": "^0.0.9",
+    "sig-beacon": "^0.0.10",
     "three": "^0.166.1",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
The beacon now properly handles relative image URLs in meta tags