### PR TITLE
Bump beacon version to 0.0.14

### DIFF
--- a/utils/package.json
+++ b/utils/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.27.2",
-    "sig-beacon": "^0.0.13",
+    "sig-beacon": "^0.0.14",
     "three": "^0.166.1",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
Incorporates changes from https://github.com/zestyxyz/beacon/pull/5