### PR TITLE
Address some breakages observed in the wild

### DIFF
--- a/aframe/package.json
+++ b/aframe/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "prettier": "1.18.2",
+    "terser-webpack-plugin": "^5.3.11",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.9.2"

--- a/aframe/webpack.config.js
+++ b/aframe/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const TerserWebpackPlugin = require('terser-webpack-plugin')
 
 module.exports = {
     entry: {
@@ -7,7 +8,50 @@ module.exports = {
     output: {
         filename: '[name].js',
         path: path.resolve(__dirname, 'dist'),
-        libraryTarget: 'module'
+        library: {
+            type: 'module'
+        }
+    },
+    optimization: {
+        minimize: true,
+        minimizer: [new TerserWebpackPlugin({
+            terserOptions: {
+                compress: {
+                    passes: 2 // Need to do 2 passes to compensate for larger mangled size
+                },
+                mangle: {
+                    nth_identifier: {
+                        get: n => {
+                            // This is needed to avoid a potential var collision
+                            // in the minified zesty-aframe-sdk bundle.
+                            // If n is less than 26, map identifier to two alphabetic characters,
+                            // i.e. 'aa', 'ab', 'ac', etc.
+                            // If greater, add another while less than 52, and so on.
+
+                            const chars = 'abcdefghijklmnopqrstuvwxyz';
+                            let result = '';
+
+                            // Calculate how many characters we need
+                            // Start with minimum of 2 characters
+                            const numChars = Math.max(2, Math.floor(n / 26) + 1);
+                            
+                            // For each position, calculate which letter it should be
+                            for (let i = 0; i < numChars; i++) {
+                                if (i === numChars - 1) {
+                                    // Last character uses the remainder
+                                    result += chars[n % 26];
+                                } else {
+                                    // Earlier characters cycle through alphabet
+                                    result += chars[i % 26];
+                                }
+                            }
+
+                            return result;
+                        }
+                    }
+                }
+            }
+        })]
     },
     devServer: {
         contentBase: __dirname,

--- a/utils/networking.js
+++ b/utils/networking.js
@@ -198,7 +198,7 @@ Check https://docs.zesty.xyz/guides/developers/ad-units for more information.`);
         currentTries[adUnitId]++;
         if (currentTries[adUnitId] == retryCount) {
           try {
-            const url = encodeURI(window.top.location.href).replace(/\/$/, ''); // If URL ends with a slash, remove it
+            const url = encodeURI(window.location.href).replace(/\/$/, ''); // If URL ends with a slash, remove it
             const res = await axios.get(`${DB_ENDPOINT}/ad?ad_unit_id=${adUnitId}&url=${url}`);
             if (res.data) {
               resolve(res.data);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4511,6 +4511,16 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
 
+schema-utils@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.0.tgz#3b669f04f71ff2dfb5aba7ce2d5a9d79b35622c0"
+  integrity sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ajv "^8.9.0"
+    ajv-formats "^2.1.1"
+    ajv-keywords "^5.1.0"
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz"
@@ -4548,7 +4558,7 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@^6.0.1:
+serialize-javascript@^6.0.1, serialize-javascript@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
   integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
@@ -4653,10 +4663,10 @@ side-channel@^1.0.6:
     get-intrinsic "^1.2.4"
     object-inspect "^1.13.1"
 
-sig-beacon@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/sig-beacon/-/sig-beacon-0.0.9.tgz#58ad3eb3fdf04a276985f0b78906054599e7b6ee"
-  integrity sha512-+rDaRwahYBgnuMiqbk/oBDPwbN2T2spBSTgtQCliq1+wu0+5qOk+6LgjKcWI+NtJ8/r6czJLoOUG/aFLp70vCA==
+sig-beacon@^0.0.14:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/sig-beacon/-/sig-beacon-0.0.14.tgz#c2434472a64cfb91c4c46cd50a131565ea81c678"
+  integrity sha512-BQo7GTCdbA+SAKBC3JcCsWNl/0mcr3aPUZInPZ9Vj+4LnSLYTWL+mWLf81/4AYh+NDl9Rf4WZVvaYR1ghuwsoA==
 
 signal-exit@^3.0.3:
   version "3.0.7"
@@ -4847,10 +4857,31 @@ terser-webpack-plugin@^5.3.10:
     serialize-javascript "^6.0.1"
     terser "^5.26.0"
 
+terser-webpack-plugin@^5.3.11:
+  version "5.3.11"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz#93c21f44ca86634257cac176f884f942b7ba3832"
+  integrity sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jest-worker "^27.4.5"
+    schema-utils "^4.3.0"
+    serialize-javascript "^6.0.2"
+    terser "^5.31.1"
+
 terser@^5.26.0:
   version "5.31.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.1.tgz#735de3c987dd671e95190e6b98cfe2f07f3cf0d4"
   integrity sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
+terser@^5.31.1:
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.39.0.tgz#0e82033ed57b3ddf1f96708d123cca717d86ca3a"
+  integrity sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"


### PR DESCRIPTION
This makes two changes based on some breakages we've seen:

- `fetchCampaignAd` no longer tries to access window.top when getting the page URL. To my knowledge there are no instances of the SDK being used in an iframe that isn't also being subjected to CORP/COEP restrictions.
- The A-Frame SDK minification process now uses a custom-defined function for producing identifier names, as it turns out it's possible for single character identifiers to collide in the production build from webpack. As far as I can tell this has only affected the A-Frame SDK.